### PR TITLE
Resolve Issue #8: Expose laminar config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Multiple sockets [#2](https://github.com/ncallaway/bevy_prototype_networking_laminar/issues/2)
+- Ability to set some Laminar config options [#8](https://github.com/ncallaway/bevy_prototype_networking_laminar/issues/8)
 
 ### Changed
 

--- a/examples/testbed/net/prototype.rs
+++ b/examples/testbed/net/prototype.rs
@@ -77,7 +77,8 @@ fn send_cube_position_system(
         net.broadcast(
             &msg.encode()[..],
             NetworkDelivery::UnreliableSequenced(Some(1)),
-        );
+        )
+        .unwrap();
     }
 }
 
@@ -93,7 +94,8 @@ fn send_create_message_system(
                     *server,
                     &TestbedMessage::CreateMessage(msg.clone()).encode()[..],
                     NetworkDelivery::ReliableOrdered(Some(1)),
-                );
+                )
+                .unwrap();
             }
         }
         _ => {}
@@ -174,7 +176,8 @@ fn handle_introduction_event(
         conn.addr,
         &TestbedMessage::Pong.encode()[..],
         NetworkDelivery::ReliableSequenced(Some(2)),
-    );
+    )
+    .expect("The introduction send failed");
     players.names.insert(conn, name.clone());
     client_update_events.send(ClientUpdateEvent {
         from: name,
@@ -226,14 +229,14 @@ fn broadcast_all_messages(net: Res<NetworkResource>, mut messages_query: Query<&
 
     let sync_messages = TestbedMessage::SyncMessages { messages: messages };
 
-    net.broadcast(
+    let _ = net.broadcast(
         &sync_messages.encode()[..],
         NetworkDelivery::ReliableSequenced(Some(1)),
     );
 }
 
 fn start_server(addr: SocketAddr, mut net: ResMut<NetworkResource>) {
-    net.bind(addr).unwrap();
+    net.bind(addr).expect("We failed to bind to the socket.");
 }
 
 fn start_client(
@@ -242,13 +245,14 @@ fn start_client(
     server_addr: SocketAddr,
     mut net: ResMut<NetworkResource>,
 ) {
-    net.bind(addr).unwrap();
+    net.bind(addr).expect("We failed to bind to the socket.");
 
     net.send(
         server_addr,
         &TestbedMessage::Introduction(name.to_string()).encode()[..],
         NetworkDelivery::ReliableSequenced(Some(1)),
-    );
+    )
+    .expect("We failed to send our introduction message");
 }
 
 impl TestbedMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,18 @@ use bevy::prelude::*;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Mutex;
-use std::time::Duration;
 
-use laminar::{Config, Socket};
+use laminar::Socket;
 
 use bytes::Bytes;
 use uuid::Uuid;
 
 mod error;
+mod transport;
 mod worker;
 
 pub use error::NetworkError;
+pub use transport::{LaminarConfig, Transport};
 
 pub struct NetworkingPlugin;
 
@@ -111,10 +112,25 @@ impl NetworkResource {
     }
 
     pub fn bind<A: ToSocketAddrs>(&mut self, addr: A) -> Result<SocketHandle, NetworkError> {
-        let mut cfg = Config::default();
-        cfg.idle_connection_timeout = Duration::from_millis(2000);
-        cfg.heartbeat_interval = Some(Duration::from_millis(1000));
-        cfg.max_packets_in_flight = 2048;
+        self.bind_with_transport(addr, Transport::Laminar(LaminarConfig::default()))
+    }
+
+    pub fn bind_with_transport<A: ToSocketAddrs>(
+        &mut self,
+        addr: A,
+        transport: Transport,
+    ) -> Result<SocketHandle, NetworkError> {
+        match transport {
+            Transport::Laminar(config) => self.bind_with_laminar(addr, config),
+        }
+    }
+
+    fn bind_with_laminar<A: ToSocketAddrs>(
+        &mut self,
+        addr: A,
+        config: LaminarConfig,
+    ) -> Result<SocketHandle, NetworkError> {
+        let cfg = config.into();
 
         let handle = SocketHandle::new();
         let socket = Socket::bind_with_config(addr, cfg)?;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,33 @@
+use laminar::Config;
+use std::time::Duration;
+
+pub enum Transport {
+    Laminar(LaminarConfig),
+}
+
+pub struct LaminarConfig {
+    pub idle_connection_timeout: Duration,
+    pub heartbeat_interval: Option<Duration>,
+    pub max_packets_in_flight: u16,
+}
+
+impl Default for LaminarConfig {
+    fn default() -> Self {
+        LaminarConfig {
+            idle_connection_timeout: Duration::from_millis(5000),
+            heartbeat_interval: Some(Duration::from_millis(1000)),
+            max_packets_in_flight: 1024,
+        }
+    }
+}
+
+impl From<LaminarConfig> for Config {
+    fn from(cfg: LaminarConfig) -> Self {
+        Config {
+            idle_connection_timeout: cfg.idle_connection_timeout,
+            heartbeat_interval: cfg.heartbeat_interval,
+            max_packets_in_flight: cfg.max_packets_in_flight,
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
This also opens the API to alternative transports (such as UDP, TCP, or others in
the future)