### PR TITLE
Cleanup/examples

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/bash
 cargo fmt
+cargo test --lib
 # cargo clippy --all-targets
 # workaround from: https://github.com/rust-lang/rust-clippy/issues/4612#issuecomment-537633718
 find . | grep "\.rs$" | grep -v "^./target" | xargs touch ; cargo clippy --all-targets -- -D warnings

--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/bash
+cargo fmt
+# cargo clippy --all-targets
+# workaround from: https://github.com/rust-lang/rust-clippy/issues/4612#issuecomment-537633718
+find . | grep "\.rs$" | grep -v "^./target" | xargs touch ; cargo clippy --all-targets -- -D warnings

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo test --all--targets

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,2 +1,2 @@
 #!/bin/bash
-cargo test --all--targets
+cargo test --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
-        continue-on-error: true # WARNING: only for this example, remove it!
         with:
           command: check
 
@@ -37,11 +36,20 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        continue-on-error: true # WARNING: only for this example, remove it!
-        with:
-          command: test
+      - uses: actions/cache@v2
+          with:
+            path: |
+              target
+            key: ${{ runner.os }}-cargo-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install alsa
+        run: sudo apt-get install --no-install-recommends libasound2-dev
+
+      - name: cargo test
+        run: cargo test --all
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   lints:
     name: Lints
@@ -58,14 +66,11 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Install alsa
+        run: sudo apt-get install --no-install-recommends libasound2-dev
 
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D warnings
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        continue-on-error: true # WARNING: only for this example, remove it!
+        with:
+          command: check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        continue-on-error: true # WARNING: only for this example, remove it!
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,46 +3,26 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
+      - name: checkout
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           override: true
 
       - uses: actions/cache@v2
-          with:
-            path: |
-              target
-            key: ${{ runner.os }}-cargo-test-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-cargo-test-stable-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install alsa
+      - name: install alsa
         run: sudo apt-get install --no-install-recommends libasound2-dev
 
       - name: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "bevy",
  "bincode",
  "bytes",
+ "cargo-husky",
  "laminar",
  "rand",
  "serde",
@@ -624,6 +625,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cart-tmp-winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "0.5.6"                               # plumbing message payloads
 uuid = { version = "0.8", features = ["v4"] } # socket handles
 
 [dev-dependencies]
+cargo-husky = { version = "1", features = ["user-hooks"] }
 smallvec = "1.4.2"
 rand = "0.7"
 serde = "1.0.115"

--- a/examples/multisocket.rs
+++ b/examples/multisocket.rs
@@ -54,7 +54,7 @@ fn send_messages(
             to,
             message.as_bytes(),
             NetworkDelivery::ReliableSequenced(Some(1)),
-            SendConfig { socket: socket },
+            SendConfig { socket },
         );
         state.from_server = from_server;
 
@@ -70,6 +70,7 @@ fn print_messages(
     if let Some(server) = sockets.server {
         if let Some(client) = sockets.client {
             for event in state.network_events.iter(&my_events) {
+                #[allow(clippy::single_match)]
                 match event {
                     NetworkEvent::Message(conn, data) => {
                         let msg = String::from_utf8_lossy(data);
@@ -84,6 +85,7 @@ fn print_messages(
 
                         println!("\t ---> [{}] {:?}\n", from, msg);
                     }
+                    NetworkEvent::Connected(conn) => println!("\t {} connected", conn),
                     _ => {}
                 }
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -118,17 +118,17 @@ pub enum ConnectionInfo {
 
 impl ConnectionInfo {
     pub fn is_server(&self) -> bool {
-        return match &self {
+        match &self {
             ConnectionInfo::Server => true,
             _ => false,
-        };
+        }
     }
 
     pub fn is_client(&self) -> bool {
-        return match &self {
+        match &self {
             ConnectionInfo::Client => true,
             _ => false,
-        };
+        }
     }
 }
 
@@ -151,5 +151,5 @@ fn parse_args() -> ConnectionInfo {
         return ConnectionInfo::Server;
     }
 
-    return ConnectionInfo::Client;
+    ConnectionInfo::Client
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,21 +1,30 @@
+use bevy::app::ScheduleRunnerPlugin;
 use bevy::prelude::*;
+
+use std::net::SocketAddr;
+use std::time::Duration;
 
 use bevy_prototype_networking_laminar::{
     NetworkDelivery, NetworkEvent, NetworkResource, NetworkingPlugin,
 };
-
-use std::net::SocketAddr;
 
 const SERVER: &str = "127.0.0.1:12351";
 const CLIENT: &str = "127.0.0.1:12350";
 
 fn main() {
     App::build()
-        .init_resource::<EventListenerState>()
-        .init_resource::<MessageTimerState>()
-        .add_resource(parse_args())
-        .add_default_plugins()
+        // minimal plugins necessary for timers + headless loop
+        .add_plugin(bevy::type_registry::TypeRegistryPlugin::default())
+        .add_plugin(bevy::core::CorePlugin)
+        .add_plugin(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
+            1.0 / 60.0,
+        )))
+        // The NetworkingPlugin
         .add_plugin(NetworkingPlugin)
+        // Our send
+        .init_resource::<NetworkEventReader>()
+        .init_resource::<SendTimer>()
+        .add_resource(parse_args())
         .add_startup_system(startup_system.system())
         .add_system(print_network_events.system())
         .add_system(send_messages.system())
@@ -23,16 +32,21 @@ fn main() {
 }
 
 #[derive(Default)]
-struct EventListenerState {
+struct NetworkEventReader {
     network_events: EventReader<NetworkEvent>,
 }
 
-fn print_network_events(
-    mut state: ResMut<EventListenerState>,
-    my_events: Res<Events<NetworkEvent>>,
-) {
-    for event in state.network_events.iter(&my_events) {
-        println!("Network Event: {:?}", event);
+fn print_network_events(mut state: ResMut<NetworkEventReader>, events: Res<Events<NetworkEvent>>) {
+    for event in state.network_events.iter(&events) {
+        match event {
+            NetworkEvent::Message(conn, data) => {
+                let msg = String::from_utf8_lossy(data);
+                println!("<--- {:?} from {}", msg, conn);
+            }
+            NetworkEvent::Connected(conn) => println!("\tConnected: {}", conn),
+            NetworkEvent::Disconnected(conn) => println!("\tDisconnected: {}", conn),
+            NetworkEvent::SendError(err) => println!("\tSend Error: {}", err),
+        }
     }
 }
 
@@ -52,14 +66,14 @@ fn start_client(mut net: ResMut<NetworkResource>) {
     net.bind(CLIENT).unwrap();
 }
 
-struct MessageTimerState {
+struct SendTimer {
     message_timer: Timer,
 }
 
-impl Default for MessageTimerState {
+impl Default for SendTimer {
     fn default() -> Self {
-        MessageTimerState {
-            message_timer: Timer::from_seconds(5.0, true),
+        SendTimer {
+            message_timer: Timer::from_seconds(3.0, true),
         }
     }
 }
@@ -67,27 +81,32 @@ impl Default for MessageTimerState {
 fn send_messages(
     ci: Res<ConnectionInfo>,
     time: Res<Time>,
-    mut state: ResMut<MessageTimerState>,
+    mut state: ResMut<SendTimer>,
     net: ResMut<NetworkResource>,
 ) {
     state.message_timer.tick(time.delta_seconds);
     if state.message_timer.finished {
         let server: SocketAddr = SERVER.parse().unwrap();
 
+        let msg = if ci.is_server() {
+            "How are things over there?"
+        } else {
+            "Good."
+        };
+
+        println!("---> {:?}", msg);
         if ci.is_server() {
-            net.broadcast(
-                b"How are things over there?",
-                NetworkDelivery::ReliableSequenced(Some(1)),
-            )
-            .unwrap()
+            net.broadcast(msg.as_bytes(), NetworkDelivery::ReliableSequenced(Some(1)))
+                .unwrap()
         } else {
             net.send(
                 server,
-                b"Good.",
+                msg.as_bytes(),
                 NetworkDelivery::ReliableSequenced(Some(1)),
             )
             .unwrap()
         }
+
         state.message_timer.reset();
     }
 }

--- a/examples/testbed/game.rs
+++ b/examples/testbed/game.rs
@@ -18,7 +18,7 @@ impl Message {
         Message {
             message: message.to_string(),
             from: from.to_string(),
-            ordinal: ordinal,
+            ordinal,
         }
     }
 }
@@ -124,21 +124,17 @@ fn message_compact_system(mut messages: Query<&mut Message>) {
 
     sorted_displays.sort_by(|a, b| a.ordinal.cmp(&b.ordinal));
 
-    let mut next = 0;
     let mut needs_compact = false;
 
-    for message in &sorted_displays {
-        if message.ordinal != next {
+    for (next, message) in sorted_displays.iter().enumerate() {
+        if message.ordinal != next as u8 {
             needs_compact = true;
         }
-        next = next + 1;
     }
 
     if needs_compact {
-        let mut next = 0;
-        for message in &mut sorted_displays {
-            message.ordinal = next;
-            next = next + 1;
+        for (next, message) in &mut sorted_displays.iter_mut().enumerate() {
+            message.ordinal = next as u8;
         }
     }
 }
@@ -186,5 +182,5 @@ fn random_message() -> String {
         "Phasellus feugiat felis at odio consectetur lacinia. Nullam fermentum malesuada consequat",
     ];
 
-    return msgs.choose(&mut rand::thread_rng()).unwrap().to_string();
+    msgs.choose(&mut rand::thread_rng()).unwrap().to_string()
 }

--- a/examples/testbed/net/mod.rs
+++ b/examples/testbed/net/mod.rs
@@ -108,7 +108,11 @@ fn handle_sync_messages_events(
         return;
     }
 
-    for event in state.sync_messages_events.iter(&sync_messages_events) {
+    if let Some(event) = state
+        .sync_messages_events
+        .iter(&sync_messages_events)
+        .next()
+    {
         let server_messages = &event.messages;
 
         let mut client_borrow = client_messages.iter();
@@ -136,25 +140,22 @@ fn handle_sync_messages_events(
         // for (e, _) in client_iter {
         //     commands.despawn(e);
         // }
-
-        // we only process one sync_message_event per frame to avoid double-spawning messages
-        break;
     }
 }
 
 impl ConnectionInfo {
     pub fn is_server(&self) -> bool {
-        return match &self {
+        match &self {
             ConnectionInfo::Server { .. } => true,
             _ => false,
-        };
+        }
     }
 
     pub fn is_client(&self) -> bool {
-        return match &self {
+        match &self {
             ConnectionInfo::Client { .. } => true,
             _ => false,
-        };
+        }
     }
 }
 
@@ -182,7 +183,7 @@ fn parse_args() -> ConnectionInfo {
         .expect("The socket address wasn't a valid format");
 
     if is_server {
-        return ConnectionInfo::Server { addr: addr };
+        return ConnectionInfo::Server { addr };
     }
 
     if args.len() < 4 {
@@ -203,9 +204,9 @@ fn parse_args() -> ConnectionInfo {
         panic!("The client name must be < 6 characters");
     }
 
-    return ConnectionInfo::Client {
+    ConnectionInfo::Client {
         name: client_name.clone(),
-        addr: addr,
+        addr,
         server: server_addr,
-    };
+    }
 }

--- a/examples/testbed/net/prototype.rs
+++ b/examples/testbed/net/prototype.rs
@@ -73,8 +73,7 @@ fn send_cube_position_system(
         let pos = tx.0;
 
         let msg = TestbedMessage::CubePosition(pos.x(), pos.y(), pos.z());
-
-        net.broadcast(
+        let _ = net.broadcast(
             &msg.encode()[..],
             NetworkDelivery::UnreliableSequenced(Some(1)),
         );
@@ -93,7 +92,8 @@ fn send_create_message_system(
                     *server,
                     &TestbedMessage::CreateMessage(msg.clone()).encode()[..],
                     NetworkDelivery::ReliableOrdered(Some(1)),
-                );
+                )
+                .expect("Create message failed to send");
             }
         }
         _ => {}
@@ -170,11 +170,12 @@ fn handle_introduction_event(
     players: &mut ResMut<Players>,
     client_update_events: &mut ResMut<Events<ClientUpdateEvent>>,
 ) {
-    net.send(
+    let _ = net.send(
         conn.addr,
         &TestbedMessage::Pong.encode()[..],
         NetworkDelivery::ReliableSequenced(Some(2)),
     );
+
     players.names.insert(conn, name.clone());
     client_update_events.send(ClientUpdateEvent {
         from: name,
@@ -226,7 +227,7 @@ fn broadcast_all_messages(net: Res<NetworkResource>, mut messages_query: Query<&
 
     let sync_messages = TestbedMessage::SyncMessages { messages: messages };
 
-    net.broadcast(
+    let _ = net.broadcast(
         &sync_messages.encode()[..],
         NetworkDelivery::ReliableSequenced(Some(1)),
     );
@@ -248,7 +249,8 @@ fn start_client(
         server_addr,
         &TestbedMessage::Introduction(name.to_string()).encode()[..],
         NetworkDelivery::ReliableSequenced(Some(1)),
-    );
+    )
+    .expect("Client introduction failed to send");
 }
 
 impl TestbedMessage {

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -268,7 +268,7 @@ fn spawn_message_display_with_entity(
     value: String,
     ordinal: u8,
 ) {
-    let md = MessageDisplay { ordinal: ordinal };
+    let md = MessageDisplay { ordinal };
 
     let e = Entity::new();
     commands
@@ -280,7 +280,7 @@ fn spawn_message_display_with_entity(
                     ..Default::default()
                 },
                 text: Text {
-                    value: value,
+                    value,
                     font: *font_handle,
                     style: TextStyle {
                         font_size: 16.0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::sync::mpsc::SendError;
 use std::sync::{MutexGuard, PoisonError};
 
-use super::{Message, SocketHandle, SocketInstruction};
+use super::{Message, SocketHandle, WorkerInstructions};
 
 #[derive(Debug)]
 pub enum NetworkError {
@@ -18,7 +18,7 @@ pub enum NetworkError {
 #[derive(Debug)]
 pub enum InternalErrorKind {
     MutexLockError,
-    SendSocketInstructionError(String),
+    SendWorkerInstructionsError(String),
     SendMessageError(String),
     LaminarError(LaminarError),
 }
@@ -41,9 +41,9 @@ impl<T> From<PoisonError<MutexGuard<'_, T>>> for NetworkError {
     }
 }
 
-impl From<SendError<SocketInstruction>> for NetworkError {
-    fn from(err: SendError<SocketInstruction>) -> Self {
-        InternalError(InternalErrorKind::SendSocketInstructionError(
+impl From<SendError<WorkerInstructions>> for NetworkError {
+    fn from(err: SendError<WorkerInstructions>) -> Self {
+        InternalError(InternalErrorKind::SendWorkerInstructionsError(
             err.to_string(),
         ))
     }
@@ -74,9 +74,9 @@ impl Display for InternalErrorKind {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match self {
             InternalErrorKind::MutexLockError => write!(fmt, "A lock could not be acquired."),
-            InternalErrorKind::SendSocketInstructionError(e) => write!(
+            InternalErrorKind::SendWorkerInstructionsError(e) => write!(
                 fmt,
-                "A socket instruction could not be sent to the worker thread ({})",
+                "A worker instruction could not be sent to the worker thread ({})",
                 e
             ),
             InternalErrorKind::SendMessageError(e) => write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+use std::fmt;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Mutex;
@@ -32,6 +33,12 @@ impl SocketHandle {
 pub struct Connection {
     pub addr: SocketAddr,
     pub socket: SocketHandle,
+}
+
+impl fmt::Display for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.addr)
+    }
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,16 +79,15 @@ impl Plugin for NetworkingPlugin {
 
 impl NetworkResource {
     pub fn connections(&self) -> &Vec<Connection> {
-        return &self.connections;
+        &self.connections
     }
 
     pub fn connections_for_socket(&self, socket: SocketHandle) -> Vec<Connection> {
-        return self
-            .connections
+        self.connections
             .iter()
             .filter(|c| c.socket == socket)
-            .map(|c| *c)
-            .collect();
+            .cloned()
+            .collect()
     }
 
     pub fn add_connection(&mut self, connection: Connection) {
@@ -138,7 +137,7 @@ impl NetworkResource {
             self.default_socket = Some(handle);
         }
 
-        return Ok(handle);
+        Ok(handle)
     }
 
     pub fn send(
@@ -165,7 +164,7 @@ impl NetworkResource {
 
         let msg = Message {
             destination: addr,
-            delivery: delivery,
+            delivery,
             socket_handle: socket,
             message: Bytes::copy_from_slice(message),
         };
@@ -188,7 +187,7 @@ impl NetworkResource {
         for conn in broadcast_to {
             let msg = Message {
                 destination: conn.addr,
-                delivery: delivery,
+                delivery,
                 socket_handle: socket,
                 message: Bytes::copy_from_slice(message),
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct NetworkResource {
     connections: Vec<Connection>,
     event_rx: Mutex<Receiver<NetworkEvent>>,
     message_tx: Mutex<Sender<Message>>,
-    instruction_tx: Mutex<Sender<SocketInstruction>>,
+    instruction_tx: Mutex<Sender<WorkerInstructions>>,
 }
 
 impl Plugin for NetworkingPlugin {
@@ -125,7 +125,7 @@ impl NetworkResource {
         let handle = SocketHandle::new();
         let socket = Socket::bind_with_config(addr, cfg)?;
 
-        let instruction = SocketInstruction::AddSocket(handle, socket);
+        let instruction = WorkerInstructions::AddSocket(handle, socket);
         {
             let locked = self.instruction_tx.lock()?;
             locked.send(instruction)?;
@@ -213,6 +213,13 @@ impl NetworkResource {
     }
 }
 
+impl Drop for NetworkResource {
+    fn drop(&mut self) {
+        let locked = self.instruction_tx.lock().unwrap();
+        locked.send(WorkerInstructions::Terminate).unwrap();
+    }
+}
+
 #[derive(Default)]
 pub struct SendConfig {
     pub socket: Option<SocketHandle>, // if none, use the default socket
@@ -226,8 +233,9 @@ struct Message {
     destination: SocketAddr,
 }
 
-enum SocketInstruction {
+enum WorkerInstructions {
     AddSocket(SocketHandle, Socket),
+    Terminate,
 }
 
 fn process_network_events(
@@ -272,5 +280,25 @@ fn process_network_events(
     for conn in removed_connections {
         net.remove_connection(conn);
         network_events.send(NetworkEvent::Disconnected(conn));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn network_resource_has_no_default_connections() {
+        let network_resource = worker::start_worker_thread();
+
+        assert!(network_resource.default_socket.is_none());
+        assert!(network_resource.bound_sockets.is_empty());
+    }
+
+    #[test]
+    fn binding_network_resource_sets_the_default_socket() {
+        let mut network_resource = worker::start_worker_thread();
+
+        assert!(network_resource.bind("127.0.0.1:12591").is_ok());
+        assert!(network_resource.default_socket.is_some());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -36,18 +36,26 @@ pub fn start_worker_thread() -> NetworkResource {
     };
 
     let mut start = std::time::Instant::now();
+    let mut end = std::time::Instant::now();
 
     thread::spawn(move || loop {
         let millis = start.elapsed().as_millis();
         if millis > 50 {
-            println!("worker elapsed: {:?}", start.elapsed());
+            println!(
+                "warning: thread worker loop took {:.3?} ({:.3?} after sleeping)",
+                start.elapsed(),
+                end.elapsed()
+            );
         }
+
         start = std::time::Instant::now();
 
         handle_instructions(&mut sockets, &instruction_rx);
         poll_sockets(&mut sockets);
         send_messages(&mut sockets, &message_rx, &event_tx);
         receive_messages(&mut sockets, &event_tx);
+
+        end = std::time::Instant::now();
 
         // go dark
         std::thread::sleep(sleep_time);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -26,7 +26,7 @@ pub fn start_worker_thread() -> NetworkResource {
         sockets: Vec::new(),
     };
 
-    let sleep_time = Duration::from_millis(250);
+    let sleep_time = Duration::from_millis(1);
 
     let resource = NetworkResource {
         default_socket: None,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -61,7 +61,7 @@ pub fn start_worker_thread() -> NetworkResource {
         std::thread::sleep(sleep_time);
     });
 
-    return resource;
+    resource
 }
 
 fn handle_instructions(sockets: &mut TrackedSockets, instruction_rx: &Receiver<SocketInstruction>) {
@@ -113,11 +113,11 @@ fn receive_messages(sockets: &mut TrackedSockets, event_tx: &Sender<NetworkEvent
         while let Some(event) = socket.recv() {
             let e = match event {
                 SocketEvent::Connect(addr) => Some(NetworkEvent::Connected(Connection {
-                    addr: addr,
+                    addr,
                     socket: *socket_handle,
                 })),
                 SocketEvent::Timeout(addr) => Some(NetworkEvent::Disconnected(Connection {
-                    addr: addr,
+                    addr,
                     socket: *socket_handle,
                 })),
                 SocketEvent::Packet(packet) => Some(NetworkEvent::Message(
@@ -144,7 +144,7 @@ struct TrackedSockets {
 
 impl TrackedSockets {
     pub fn iter_mut(&mut self) -> std::slice::IterMut<(SocketHandle, Socket)> {
-        return self.sockets.iter_mut();
+        self.sockets.iter_mut()
     }
 
     pub fn add_socket(&mut self, handle: SocketHandle, socket: Socket) {
@@ -156,7 +156,7 @@ impl TrackedSockets {
             return;
         }
 
-        return self.sockets.push((handle, socket));
+        self.sockets.push((handle, socket));
     }
 
     // pub fn close_socket(&mut self, handle: SocketHandle) {
@@ -173,17 +173,14 @@ impl TrackedSockets {
     // }
 
     pub fn has_socket(&self, handle: SocketHandle) -> bool {
-        return match self.get_socket(handle) {
-            Ok(_) => true,
-            Err(_) => false,
-        };
+        self.get_socket(handle).is_ok()
     }
 
     pub fn get_socket(&self, handle: SocketHandle) -> Result<&Socket, NetworkError> {
         self.sockets
             .iter()
             .find(|(h, _)| handle == *h)
-            .and_then(|(_, s)| Some(s))
+            .map(|(_, s)| s)
             .ok_or(NetworkError::NoSocket(handle))
     }
 
@@ -191,7 +188,7 @@ impl TrackedSockets {
         self.sockets
             .iter_mut()
             .find(|(h, _)| handle == *h)
-            .and_then(|(_, s)| Some(s))
+            .map(|(_, s)| s)
             .ok_or(NetworkError::NoSocket(handle))
     }
 }


### PR DESCRIPTION
This does a fair amount of cleanup:

* Fix warnings for examples
* Fix all `clippy` warnings for examples/code
* Add `cargo-husky` to automatically setup git hooks
* Create `pre-commit` and `pre-push` hooks
* Add github actions CI workflow
* Add a couple of tests to exercise the CI
